### PR TITLE
Add OffsetDateTimeDeserializer

### DIFF
--- a/src/main/java/com/chavaillaz/jira/client/AbstractHttpClient.java
+++ b/src/main/java/com/chavaillaz/jira/client/AbstractHttpClient.java
@@ -13,6 +13,7 @@ import java.util.Collection;
 import java.util.Map;
 
 import com.chavaillaz.jira.client.jackson.OffsetDateTimeSerializer;
+import com.chavaillaz.jira.client.jackson.OffsetDateTimeDeserializer;
 import com.chavaillaz.jira.exception.DeserializationException;
 import com.chavaillaz.jira.exception.SerializationException;
 import com.fasterxml.jackson.databind.JavaType;
@@ -55,7 +56,8 @@ public abstract class AbstractHttpClient {
     protected ObjectMapper buildObjectMapper() {
         return JsonMapper.builder()
                 .addModule(new JavaTimeModule()
-                        .addSerializer(OffsetDateTime.class, new OffsetDateTimeSerializer()))
+                        .addSerializer(OffsetDateTime.class, new OffsetDateTimeSerializer())
+                        .addDeserializer(OffsetDateTime.class, new OffsetDateTimeDeserializer()))
                 .serializationInclusion(NON_NULL)
                 .enable(ACCEPT_CASE_INSENSITIVE_PROPERTIES)
                 .disable(WRITE_DATES_AS_TIMESTAMPS)

--- a/src/main/java/com/chavaillaz/jira/client/jackson/OffsetDateTimeDeserializer.java
+++ b/src/main/java/com/chavaillaz/jira/client/jackson/OffsetDateTimeDeserializer.java
@@ -1,0 +1,20 @@
+package com.chavaillaz.jira.client.jackson;
+
+import com.fasterxml.jackson.core.JsonParser;
+import com.fasterxml.jackson.databind.DeserializationContext;
+import com.fasterxml.jackson.databind.JsonDeserializer;
+
+import java.io.IOException;
+import java.time.OffsetDateTime;
+import java.time.format.DateTimeFormatter;
+
+public class OffsetDateTimeDeserializer extends JsonDeserializer<OffsetDateTime> {
+    private static final DateTimeFormatter formatter = DateTimeFormatter.ofPattern("yyyy-MM-dd'T'HH:mm:ss.SSSZ");
+
+    @Override
+    public OffsetDateTime deserialize(final JsonParser jsonParser, final DeserializationContext deserializationContext)
+            throws IOException {
+        String dateString = jsonParser.getText();
+        return OffsetDateTime.parse(dateString, formatter);
+    }
+}


### PR DESCRIPTION
Adds a deserializer for OffsetDateTime. This is required because Jira times are reported as `yyyy-MM-dd'T'HH:mm:ss.SSSZ` instead of the default pattern of `yyyy-MM-dd'T'HH:mm:ss.SSSxx` used by the `JavaTimeModule`.