### PR TITLE
Add Version API with get and update operations

### DIFF
--- a/README.md
+++ b/README.md
@@ -182,6 +182,10 @@ It requires the following dependency:
   - `getUser(String username)`
   - `getUserOptional(String username)`
   - `getCurrentUser()`
+- **[VersionApi](src/main/java/com/chavaillaz/client/jira/api/VersionApi.java) -
+  A few operations for versions**
+  - `getVersion(String versionId)`
+  - `updateVersion(Version version)`
 
 ### Client instantiation
 

--- a/src/main/java/com/chavaillaz/client/jira/AbstractJiraClient.java
+++ b/src/main/java/com/chavaillaz/client/jira/AbstractJiraClient.java
@@ -6,6 +6,7 @@ import com.chavaillaz.client.jira.api.IssueApi;
 import com.chavaillaz.client.jira.api.ProjectApi;
 import com.chavaillaz.client.jira.api.SearchApi;
 import com.chavaillaz.client.jira.api.UserApi;
+import com.chavaillaz.client.jira.api.VersionApi;
 import com.chavaillaz.client.jira.domain.Issue;
 import com.chavaillaz.client.jira.domain.Issues;
 import com.fasterxml.jackson.databind.JavaType;
@@ -24,6 +25,7 @@ public abstract class AbstractJiraClient<C, I extends Issue> extends AbstractCli
     protected final LazyCachedObject<ProjectApi> projectApi = new LazyCachedObject<>();
     protected final LazyCachedObject<SearchApi<Issues<I>>> searchApi = new LazyCachedObject<>();
     protected final LazyCachedObject<UserApi> userApi = new LazyCachedObject<>();
+    protected final LazyCachedObject<VersionApi> versionApi = new LazyCachedObject<>();
 
     protected final Class<I> issueType;
     protected final JavaType issuesListType;

--- a/src/main/java/com/chavaillaz/client/jira/JiraClient.java
+++ b/src/main/java/com/chavaillaz/client/jira/JiraClient.java
@@ -6,6 +6,7 @@ import com.chavaillaz.client.jira.api.IssueApi;
 import com.chavaillaz.client.jira.api.ProjectApi;
 import com.chavaillaz.client.jira.api.SearchApi;
 import com.chavaillaz.client.jira.api.UserApi;
+import com.chavaillaz.client.jira.api.VersionApi;
 import com.chavaillaz.client.jira.domain.Issue;
 import com.chavaillaz.client.jira.domain.Issues;
 import com.chavaillaz.client.jira.java.JavaHttpJiraClient;
@@ -77,5 +78,12 @@ public interface JiraClient<I extends Issue> extends Client<JiraClient<I>> {
      * @return The project client
      */
     UserApi getUserApi();
+
+    /**
+     * Gets the version API.
+     *
+     * @return The version client
+     */
+    VersionApi getVersionApi();
 
 }

--- a/src/main/java/com/chavaillaz/client/jira/apache/ApacheHttpJiraClient.java
+++ b/src/main/java/com/chavaillaz/client/jira/apache/ApacheHttpJiraClient.java
@@ -9,6 +9,7 @@ import com.chavaillaz.client.jira.api.IssueApi;
 import com.chavaillaz.client.jira.api.ProjectApi;
 import com.chavaillaz.client.jira.api.SearchApi;
 import com.chavaillaz.client.jira.api.UserApi;
+import com.chavaillaz.client.jira.api.VersionApi;
 import com.chavaillaz.client.jira.domain.Issue;
 import com.chavaillaz.client.jira.domain.Issues;
 import org.apache.hc.client5.http.impl.async.CloseableHttpAsyncClient;
@@ -48,6 +49,11 @@ public class ApacheHttpJiraClient<I extends Issue> extends AbstractJiraClient<Cl
     @Override
     public SearchApi<Issues<I>> getSearchApi() {
         return searchApi.get(() -> new ApacheHttpSearchApi<>(newHttpClient(), baseUrl + BASE_API, authentication, issuesListType));
+    }
+
+    @Override
+    public VersionApi getVersionApi() {
+        return versionApi.get(() -> new ApacheHttpVersionApi(newHttpClient(), baseUrl + BASE_API, authentication));
     }
 
 }

--- a/src/main/java/com/chavaillaz/client/jira/apache/ApacheHttpVersionApi.java
+++ b/src/main/java/com/chavaillaz/client/jira/apache/ApacheHttpVersionApi.java
@@ -1,0 +1,38 @@
+package com.chavaillaz.client.jira.apache;
+
+import static org.apache.hc.client5.http.async.methods.SimpleRequestBuilder.get;
+import static org.apache.hc.client5.http.async.methods.SimpleRequestBuilder.put;
+import static org.apache.hc.core5.http.ContentType.APPLICATION_JSON;
+
+import java.util.concurrent.CompletableFuture;
+
+import com.chavaillaz.client.common.security.Authentication;
+import com.chavaillaz.client.jira.api.VersionApi;
+import com.chavaillaz.client.jira.domain.Version;
+import org.apache.hc.client5.http.impl.async.CloseableHttpAsyncClient;
+
+public class ApacheHttpVersionApi extends AbstractApacheHttpClient implements VersionApi {
+
+    /**
+     * Creates a new {@link VersionApi} using Apache HTTP client.
+     *
+     * @param client         The Apache HTTP client to use
+     * @param baseUrl        The URL of Jira
+     * @param authentication The authentication information
+     */
+    public ApacheHttpVersionApi(CloseableHttpAsyncClient client, String baseUrl, Authentication authentication) {
+        super(client, baseUrl, authentication);
+    }
+
+    @Override
+    public CompletableFuture<Version> getVersion(String versionId) {
+        return sendAsync(requestBuilder(get(), URL_VERSION, versionId), Version.class);
+    }
+
+    @Override
+    public CompletableFuture<Version> updateVersion(Version version) {
+        return sendAsync(requestBuilder(put(), URL_VERSION, version.getId())
+                .setBody(serialize(version), APPLICATION_JSON), Version.class);
+    }
+
+}

--- a/src/main/java/com/chavaillaz/client/jira/api/VersionApi.java
+++ b/src/main/java/com/chavaillaz/client/jira/api/VersionApi.java
@@ -1,0 +1,27 @@
+package com.chavaillaz.client.jira.api;
+
+import java.util.concurrent.CompletableFuture;
+
+import com.chavaillaz.client.jira.domain.Version;
+
+public interface VersionApi extends AutoCloseable {
+
+    String URL_VERSION = "version/{0}";
+
+    /**
+     * Gets a specific version.
+     *
+     * @param versionId The version identifier
+     * @return A {@link CompletableFuture} with the version
+     */
+    CompletableFuture<Version> getVersion(String versionId);
+
+    /**
+     * Updates a version.
+     *
+     * @param versionId The version identifier
+     * @param version   The version to update
+     * @return A {@link CompletableFuture} with the updated version
+     */
+    CompletableFuture<Version> updateVersion(Version version);
+}

--- a/src/main/java/com/chavaillaz/client/jira/java/JavaHttpJiraClient.java
+++ b/src/main/java/com/chavaillaz/client/jira/java/JavaHttpJiraClient.java
@@ -11,6 +11,7 @@ import com.chavaillaz.client.jira.api.IssueApi;
 import com.chavaillaz.client.jira.api.ProjectApi;
 import com.chavaillaz.client.jira.api.SearchApi;
 import com.chavaillaz.client.jira.api.UserApi;
+import com.chavaillaz.client.jira.api.VersionApi;
 import com.chavaillaz.client.jira.domain.Issue;
 import com.chavaillaz.client.jira.domain.Issues;
 
@@ -49,6 +50,11 @@ public class JavaHttpJiraClient<I extends Issue> extends AbstractJiraClient<Http
     @Override
     public SearchApi<Issues<I>> getSearchApi() {
         return searchApi.get(() -> new JavaHttpSearchApi<>(newHttpClient(), baseUrl + BASE_API, authentication, issuesListType));
+    }
+
+    @Override
+    public VersionApi getVersionApi() {
+        return versionApi.get(() -> new JavaHttpVersionApi(newHttpClient(), baseUrl + BASE_API, authentication));
     }
 
 }

--- a/src/main/java/com/chavaillaz/client/jira/java/JavaHttpVersionApi.java
+++ b/src/main/java/com/chavaillaz/client/jira/java/JavaHttpVersionApi.java
@@ -1,0 +1,33 @@
+package com.chavaillaz.client.jira.java;
+
+import java.net.http.HttpClient;
+import java.util.concurrent.CompletableFuture;
+
+import com.chavaillaz.client.common.security.Authentication;
+import com.chavaillaz.client.jira.api.VersionApi;
+import com.chavaillaz.client.jira.domain.Version;
+
+public class JavaHttpVersionApi extends AbstractJavaHttpClient implements VersionApi {
+
+    /**
+     * Creates a new {@link VersionApi} using Java HTTP client.
+     *
+     * @param client         The Java HTTP client to use
+     * @param baseUrl        The URL of Jira
+     * @param authentication The authentication information
+     */
+    public JavaHttpVersionApi(HttpClient client, String baseUrl, Authentication authentication) {
+        super(client, baseUrl, authentication);
+    }
+
+    @Override
+    public CompletableFuture<Version> getVersion(String versionId) {
+        return sendAsync(requestBuilder(URL_VERSION, versionId).GET(), Version.class);
+    }
+
+    @Override
+    public CompletableFuture<Version> updateVersion(Version version) {
+        return sendAsync(requestBuilder(URL_VERSION, version.getId()).PUT(body(version)), Version.class);
+    }
+
+}

--- a/src/main/java/com/chavaillaz/client/jira/okhttp/OkHttpJiraClient.java
+++ b/src/main/java/com/chavaillaz/client/jira/okhttp/OkHttpJiraClient.java
@@ -9,6 +9,7 @@ import com.chavaillaz.client.jira.api.IssueApi;
 import com.chavaillaz.client.jira.api.ProjectApi;
 import com.chavaillaz.client.jira.api.SearchApi;
 import com.chavaillaz.client.jira.api.UserApi;
+import com.chavaillaz.client.jira.api.VersionApi;
 import com.chavaillaz.client.jira.domain.Issue;
 import com.chavaillaz.client.jira.domain.Issues;
 import okhttp3.OkHttpClient;
@@ -48,6 +49,11 @@ public class OkHttpJiraClient<I extends Issue> extends AbstractJiraClient<OkHttp
     @Override
     public SearchApi<Issues<I>> getSearchApi() {
         return searchApi.get(() -> new OkHttpSearchApi<>(newHttpClient(), baseUrl + BASE_API, authentication, issuesListType));
+    }
+
+    @Override
+    public VersionApi getVersionApi() {
+        return versionApi.get(() -> new OkHttpVersionApi(newHttpClient(), baseUrl + BASE_API, authentication));
     }
 
 }

--- a/src/main/java/com/chavaillaz/client/jira/okhttp/OkHttpVersionApi.java
+++ b/src/main/java/com/chavaillaz/client/jira/okhttp/OkHttpVersionApi.java
@@ -1,0 +1,32 @@
+package com.chavaillaz.client.jira.okhttp;
+
+import java.util.concurrent.CompletableFuture;
+
+import com.chavaillaz.client.common.security.Authentication;
+import com.chavaillaz.client.jira.api.VersionApi;
+import com.chavaillaz.client.jira.domain.Version;
+import okhttp3.OkHttpClient;
+
+public class OkHttpVersionApi extends AbstractOkHttpClient implements VersionApi {
+
+    /**
+     * Creates a new {@link VersionApi} using OkHttp client.
+     *
+     * @param client         The OkHttp client to use
+     * @param baseUrl        The URL of Jira
+     * @param authentication The authentication information
+     */
+    public OkHttpVersionApi(OkHttpClient client, String baseUrl, Authentication authentication) {
+        super(client, baseUrl, authentication);
+    }
+    @Override
+    public CompletableFuture<Version> getVersion(String versionId) {
+        return sendAsync(requestBuilder(URL_VERSION, versionId).get(), Version.class);
+    }
+
+    @Override
+    public CompletableFuture<Version> updateVersion(Version version) {
+        return sendAsync(requestBuilder(URL_VERSION, version.getId()).put(body(version)), Version.class);
+    }
+
+}

--- a/src/main/java/com/chavaillaz/client/jira/vertx/VertxHttpJiraClient.java
+++ b/src/main/java/com/chavaillaz/client/jira/vertx/VertxHttpJiraClient.java
@@ -9,6 +9,7 @@ import com.chavaillaz.client.jira.api.IssueApi;
 import com.chavaillaz.client.jira.api.ProjectApi;
 import com.chavaillaz.client.jira.api.SearchApi;
 import com.chavaillaz.client.jira.api.UserApi;
+import com.chavaillaz.client.jira.api.VersionApi;
 import com.chavaillaz.client.jira.domain.Issue;
 import com.chavaillaz.client.jira.domain.Issues;
 import io.vertx.core.Vertx;
@@ -63,6 +64,11 @@ public class VertxHttpJiraClient<I extends Issue> extends AbstractJiraClient<Web
     @Override
     public SearchApi<Issues<I>> getSearchApi() {
         return searchApi.get(() -> new VertxHttpSearchApi<>(newHttpClient(), baseUrl + BASE_API, authentication, issuesListType));
+    }
+
+    @Override
+    public VersionApi getVersionApi() {
+        return versionApi.get(() -> new VertxHttpVersionApi(newHttpClient(), baseUrl + BASE_API, authentication));
     }
 
 

--- a/src/main/java/com/chavaillaz/client/jira/vertx/VertxHttpVersionApi.java
+++ b/src/main/java/com/chavaillaz/client/jira/vertx/VertxHttpVersionApi.java
@@ -1,0 +1,36 @@
+package com.chavaillaz.client.jira.vertx;
+
+import static io.vertx.core.http.HttpMethod.GET;
+import static io.vertx.core.http.HttpMethod.PUT;
+
+import java.util.concurrent.CompletableFuture;
+
+import com.chavaillaz.client.common.security.Authentication;
+import com.chavaillaz.client.jira.api.VersionApi;
+import com.chavaillaz.client.jira.domain.Version;
+import io.vertx.ext.web.client.WebClient;
+
+public class VertxHttpVersionApi extends AbstractVertxHttpClient implements VersionApi {
+
+    /**
+     * Creates a new {@link VersionApi} using Vert.x client.
+     *
+     * @param client         The Vert.x client to use
+     * @param baseUrl        The URL of Jira
+     * @param authentication The authentication information
+     */
+    public VertxHttpVersionApi(WebClient client, String baseUrl, Authentication authentication) {
+        super(client, baseUrl, authentication);
+    }
+
+    @Override
+    public CompletableFuture<Version> getVersion(String versionId) {
+        return handleAsync(requestBuilder(GET, URL_VERSION, versionId).send(), Version.class);
+    }
+
+    @Override
+    public CompletableFuture<Version> updateVersion(Version version) {
+        return handleAsync(requestBuilder(PUT, URL_VERSION, version.getId()).sendBuffer(body(version)), Version.class);
+    }
+
+}


### PR DESCRIPTION
This adds a new VersionApi with 2 operations: "get version" and "update version".
See their documentation at https://docs.atlassian.com/software/jira/docs/api/REST/9.12.0/#api/2/version

This works with my Jira 9.12.10 instance.

Other operations could probably be added (create, delete, etc.), but I don't need them for now, so they would be a bit tedious for me to test.